### PR TITLE
Extract baseState into its own class

### DIFF
--- a/baseState.py
+++ b/baseState.py
@@ -1,0 +1,36 @@
+# baseState.
+
+# Base class for implementing a state machine.
+
+# Written by Patch Salts.
+# Last edited 06/03/2024
+
+class baseState:
+    """Base class for states.
+
+    Attributes:
+        model: The model this state is attached to.
+    """
+    def __init__(self, model):
+        """Construct baseState.
+
+        Parameters:
+            model: The model this state is attached to.
+        """
+        self.model = model
+
+    def enter(self):
+        """Run setup actions when entering state."""
+        pass
+
+    def exit(self):
+        """Run cleanup actions when exiting the state."""
+        pass
+
+    def update(self) -> baseState:
+        """Update the model.
+
+        Returns:
+            baseState: Optional class of state to transition into.
+        """
+        pass

--- a/stopwatchModel.py
+++ b/stopwatchModel.py
@@ -3,9 +3,10 @@
 # Classes implementing a stopwatch.
 
 # Written by Patch Salts.
-# Last edited 05/31/2024
+# Last edited 06/03/2024
 
 import time
+import baseState
 
 class stopwatchModel:
     """Class for operating a stopwatch.
@@ -57,7 +58,7 @@ class stopwatchModel:
         if newState is not None:
             self.transition(newState)
 
-class stopwatchModelState:
+class stopwatchModelState(baseState.baseState):
     """Base class for states for stopwatchModel.
     
     Attributes:
@@ -69,15 +70,7 @@ class stopwatchModelState:
         Parameters:
             model (stopwatchModel): The model this state is attached to.
         """
-        self.model = model
-
-    def enter(self):
-        """Run setup actions when entering state."""
-        pass
-
-    def exit(self):
-        """Run cleanup actions when exiting state."""
-        pass
+        super().__init__(model)
 
     def update(self) -> stopwatchModelState:
         """Update the model.


### PR DESCRIPTION
Now that the timer feature will be implemented soon, it's a good idea to move the baseState into its own class so that there isn't too much nonsense duplicate code in the code base.